### PR TITLE
Don't bundle @shikijs/langs and @shikijs/themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
   ],
   "dependencies": {
     "@shikijs/engine-oniguruma": "^3.2.1",
+    "@shikijs/langs": "^3.2.1",
+    "@shikijs/themes": "^3.2.1",
     "@shikijs/types": "^3.2.1",
     "@shikijs/vscode-textmate": "^10.0.2"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,6 +13,8 @@ export default [
       "@shikijs/vscode-textmate",
       "@shikijs/engine-oniguruma",
       "@shikijs/types",
+      /^@shikijs\/langs/,
+      /^@shikijs\/themes/,
     ],
     plugins: [typescript(), nodeResolve()],
   },

--- a/scripts/update_shiki.sh
+++ b/scripts/update_shiki.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Install the latest version
-npm i shiki@latest @shikijs/engine-oniguruma@latest @shikijs/types@latest @shikijs/vscode-textmate@latest
+npm i shiki@latest @shikijs/engine-oniguruma@latest @shikijs/types@latest @shikijs/vscode-textmate@latest @shikijs/langs@latest @shikijs/themes@latest
 
 # Build
 npm run build


### PR DESCRIPTION
I noticed that `mini-shiki` re-bundles every languages and places them under `mini-shiki/dist/`. Considering the size of language files (e.g. 659K for `mini-shiki/dist/cpp-BX9S9GZ6.js`), it's better to add `@shikijs/langs` as a dependency, and re-use language files from `@shikijs/langs`. Same for `@shikijs/themes`. 

This PR updates the rollup config to exclude `@shikijs/langs` and `@shikijs/themes`.

Before:

```bash
$ tree dist/
dist/
├── abap-Cl_nMO0f.js
├── actionscript-3-BUPGSqUM.js
├── ada-CiK2fhYW.js
...
├── shiki.d.ts
├── shiki.js
...
```

```bash
$ cat dist/shiki.js
...
    "import": () => import('./actionscript-3-BUPGSqUM.js')
...
    "import": () => import('./vitesse-light-D27naoFF.js')
...
```

After:

```bash
$ tree dist/
dist/
├── onig.wasm
├── shiki.d.ts
└── shiki.js
```

```bash
$ cat dist/shiki.js
...
    "import": () => import('@shikijs/langs/actionscript-3')
...
    "import": () => import('@shikijs/themes/vitesse-light')
...
```